### PR TITLE
Hide complaint priority from all passenger views (#12)

### DIFF
--- a/frontend/src/components/complaints/ComplaintList.tsx
+++ b/frontend/src/components/complaints/ComplaintList.tsx
@@ -11,6 +11,7 @@ interface ComplaintListProps {
   loading?: boolean;
   onViewDetails?: (complaint: Complaint) => void;
   showAssignee?: boolean;
+  showPriority?: boolean;
 }
 
 export const ComplaintList: React.FC<ComplaintListProps> = ({
@@ -18,6 +19,7 @@ export const ComplaintList: React.FC<ComplaintListProps> = ({
   loading = false,
   onViewDetails,
   showAssignee = false,
+  showPriority = true,
 }) => {
   if (loading) {
     return (
@@ -70,7 +72,7 @@ export const ComplaintList: React.FC<ComplaintListProps> = ({
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {complaints.map((complaint) => (
-        <Card key={complaint.id} hover className="transition-all duration-200">
+        <Card key={complaint._id} hover className="transition-all duration-200">
           <CardContent>
             <div className="space-y-3">
               <div className="flex justify-between items-start">
@@ -79,7 +81,7 @@ export const ComplaintList: React.FC<ComplaintListProps> = ({
                 </h3>
                 <div className="flex space-x-1">
                   <StatusBadge status={complaint.status} />
-                  <PriorityBadge priority={complaint.priority} />
+                  {showPriority && <PriorityBadge priority={complaint.priority} />}
                 </div>
               </div>
 

--- a/frontend/src/pages/passenger/ComplaintDetails.tsx
+++ b/frontend/src/pages/passenger/ComplaintDetails.tsx
@@ -143,9 +143,9 @@ export const ComplaintDetails: React.FC = () => {
           <Badge variant={getStatusColor(complaint.status)}>
             {complaint.status.replace('-', ' ').toUpperCase()}
           </Badge>
-          <Badge variant={getPriorityColor(complaint.priority)}>
+          {/* <Badge variant={getPriorityColor(complaint.priority)}>
             {complaint.priority.toUpperCase()} PRIORITY
-          </Badge>
+          </Badge> */}
         </div>
       </div>
 

--- a/frontend/src/pages/passenger/MyComplaints.tsx
+++ b/frontend/src/pages/passenger/MyComplaints.tsx
@@ -187,9 +187,9 @@ useEffect(() => {
                   <Badge variant={getStatusColor(complaint.status)}>
                     {complaint.status.replace('-', ' ').toUpperCase()}
                   </Badge>
-                  <Badge variant={getPriorityColor(complaint.priority)}>
+                  {/* <Badge variant={getPriorityColor(complaint.priority)}>
                     {complaint.priority.toUpperCase()} PRIORITY
-                  </Badge>
+                  </Badge> */}
                 </div>
               </div>
 

--- a/frontend/src/pages/passenger/Passengerdashboard.tsx
+++ b/frontend/src/pages/passenger/Passengerdashboard.tsx
@@ -7,10 +7,10 @@ import { StatCard } from '../../components/dashboard/StatCard';
 import { ComplaintList } from '../../components/complaints/ComplaintList';
 import { apiClient } from '../../lib/api';
 import { Complaint } from '../../types';
-import { useSyncUserEmail } from '../../useSyncUserEmail'; //new import
+import { useSyncUserEmail } from '../../useSyncUserEmail'; // new import
 
 export const PassengerDashboard: React.FC = () => {
-  useSyncUserEmail(); //ensures userEmail is stored in localStorage after login
+  useSyncUserEmail(); // ensures userEmail is stored in localStorage after login
 
   const [complaints, setComplaints] = useState<Complaint[]>([]);
   const [loading, setLoading] = useState(true);
@@ -44,7 +44,9 @@ export const PassengerDashboard: React.FC = () => {
         const total = response.data.length;
         const pending = response.data.filter(c => c.status === 'pending').length;
         const inProgress = response.data.filter(c => c.status === 'in-progress').length;
-        const resolved = response.data.filter(c => c.status === 'resolved' || c.status === 'closed').length;
+        const resolved = response.data.filter(
+          c => c.status === 'resolved' || c.status === 'closed'
+        ).length;
 
         setStats({ total, pending, inProgress, resolved });
       }
@@ -54,7 +56,6 @@ export const PassengerDashboard: React.FC = () => {
       setLoading(false);
     }
   };
-
 
   const handleViewDetails = (complaint: Complaint) => {
     // Navigate to complaint details page
@@ -138,10 +139,12 @@ export const PassengerDashboard: React.FC = () => {
           </Link>
         </div>
 
+        {/* Hide priority in ComplaintList */}
         <ComplaintList
           complaints={complaints}
           loading={loading}
           onViewDetails={handleViewDetails}
+          showPriority={false} 
         />
       </div>
     </div>


### PR DESCRIPTION

This PR hides the complaint priority (e.g., HIGH, MEDIUM, LOW) from all passenger views.

Changes Made

1. Removed priority badge from `MyComplaints.tsx`
2. Removed priority badge from `ComplaintDetails.tsx`
3. Removed priority badge from shared `ComplaintList.tsx`
4. Cleaned up unused helper function `getPriorityColor()`

How to Test

1. Run frontend and backend.
2. Log in as a passenger.
3. Visit:
   - `/passenger/dashboard`
   - `/passenger/complaints`
   - `/passenger/complaints/<id>`
4. Confirm that no priority labels are visible, but status labels still appear.

Linked Issue Closes #12
