### PR TITLE
fix: correct View Details button navigation in Passenger Dashboard (#18)

### DIFF
--- a/frontend/src/pages/passenger/Passengerdashboard.tsx
+++ b/frontend/src/pages/passenger/Passengerdashboard.tsx
@@ -8,6 +8,7 @@ import { ComplaintList } from '../../components/complaints/ComplaintList';
 import { apiClient } from '../../lib/api';
 import { Complaint } from '../../types';
 import { useSyncUserEmail } from '../../useSyncUserEmail'; // new import
+import { useNavigate } from 'react-router-dom';
 
 export const PassengerDashboard: React.FC = () => {
   useSyncUserEmail(); // ensures userEmail is stored in localStorage after login
@@ -57,9 +58,10 @@ export const PassengerDashboard: React.FC = () => {
     }
   };
 
+  const navigate = useNavigate();
+
   const handleViewDetails = (complaint: Complaint) => {
-    // Navigate to complaint details page
-    window.open(`/passenger/complaints/${complaint._id}`, '_blank');
+    navigate(`/passenger/complaints/${complaint._id}`);
   };
 
   return (


### PR DESCRIPTION
Fixes the issue where clicking the “View Details” button in the Passenger Dashboard opened another dashboard tab instead of the correct complaint details page.

Changes Made

1. Replaced `window.open()` with React Router `navigate()` function.
2. Ensured navigation points to `/passenger/complaints/:id` using the complaint’s `_id`.

How to Test

1. Run frontend and backend.
2. Go to `/passenger/dashboard`.
3. Click “View Details” on any complaint.
4. Verify smooth navigation to `/passenger/complaints/<id>` without reload.

Linked Issue - Closes #18 
